### PR TITLE
Add skeleton planning and progress modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # pedagogy-interface
-SOLO, Rosenshine, Harlen
+
+A minimal starting point for an educational planning and progress tracking
+application. The repository currently contains two core modules:
+
+- `pedagogy/planning.py` – data structures for unit and lesson planning.
+- `pedagogy/progress.py` – simple progress tracking aligned with SOLO taxonomy.
+
+## Development
+
+1. Create a virtual environment and install dependencies (none required yet).
+2. Run the tests:
+
+```bash
+pytest
+```
+
+These modules form the foundation for future features integrating
+curriculum alignment and detailed analytics.

--- a/pedagogy/__init__.py
+++ b/pedagogy/__init__.py
@@ -1,0 +1,1 @@
+# pedagogy package

--- a/pedagogy/planning.py
+++ b/pedagogy/planning.py
@@ -1,0 +1,71 @@
+"""Planning module for curriculum design.
+
+Defines classes for skills, content descriptors, achievement standards,
+lesson plans and unit plans. These classes provide simple container
+structures to store curriculum information and enable linkage between
+curriculum frameworks and classroom planning.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Skill:
+    """Represents a specific skill within a content descriptor."""
+
+    name: str
+    description: str = ""
+
+
+@dataclass
+class ContentDescriptor:
+    """A descriptor within an achievement standard."""
+
+    code: str
+    description: str
+    skills: List[Skill] = field(default_factory=list)
+
+    def add_skill(self, skill: Skill) -> None:
+        """Attach a skill to this descriptor."""
+        self.skills.append(skill)
+
+
+@dataclass
+class AchievementStandard:
+    """Sentence from the curriculum describing expected achievement."""
+
+    sentence: str
+    descriptors: List[ContentDescriptor] = field(default_factory=list)
+
+    def add_descriptor(self, descriptor: ContentDescriptor) -> None:
+        """Attach a content descriptor to the standard."""
+        self.descriptors.append(descriptor)
+
+
+@dataclass
+class LessonPlan:
+    """A single lesson within a unit plan."""
+
+    title: str
+    activities: List[str] = field(default_factory=list)
+
+
+@dataclass
+class UnitPlan:
+    """A unit plan mapping lessons to curriculum outcomes."""
+
+    title: str
+    year_group: int
+    achievement_standards: List[AchievementStandard] = field(default_factory=list)
+    lessons: List[LessonPlan] = field(default_factory=list)
+
+    def add_achievement_standard(self, standard: AchievementStandard) -> None:
+        """Add an achievement standard that the unit addresses."""
+        self.achievement_standards.append(standard)
+
+    def add_lesson(self, lesson: LessonPlan) -> None:
+        """Insert a lesson into the unit plan."""
+        self.lessons.append(lesson)

--- a/pedagogy/progress.py
+++ b/pedagogy/progress.py
@@ -1,0 +1,58 @@
+"""Progress tracking module.
+
+Provides simple data structures to record student progress through
+SOLO taxonomy levels for specific skills. The module focuses on core
+data capture functionality required for classroom use.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from enum import Enum
+from typing import List
+
+from .planning import Skill
+
+
+class SoloLevel(str, Enum):
+    """Enumeration of SOLO taxonomy levels."""
+
+    PRE_STRUCTURAL = "Pre-structural"
+    UNI_STRUCTURAL = "Uni-structural"
+    MULTI_STRUCTURAL = "Multi-structural"
+    RELATIONAL = "Relational"
+    EXTENDED_ABSTRACT = "Extended Abstract"
+
+
+@dataclass
+class Student:
+    """Represents a student whose progress is tracked."""
+
+    name: str
+    student_id: str
+
+
+@dataclass
+class ProgressEntry:
+    """Record of a student's SOLO level for a specific skill."""
+
+    student: Student
+    skill: Skill
+    solo_level: SoloLevel
+    recorded_on: date = field(default_factory=date.today)
+
+
+@dataclass
+class ProgressTracker:
+    """Container for storing multiple progress entries."""
+
+    entries: List[ProgressEntry] = field(default_factory=list)
+
+    def record_progress(self, student: Student, skill: Skill, level: SoloLevel) -> None:
+        """Create a new progress entry for a student and skill."""
+        self.entries.append(ProgressEntry(student, skill, level))
+
+    def get_student_progress(self, student: Student) -> List[ProgressEntry]:
+        """Return all progress entries for the given student."""
+        return [entry for entry in self.entries if entry.student == student]

--- a/tests/test_pedagogy.py
+++ b/tests/test_pedagogy.py
@@ -1,0 +1,42 @@
+"""Basic tests for planning and progress modules."""
+
+import pathlib
+import sys
+
+# Ensure the package root is on the Python path
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+from pedagogy.planning import (
+    AchievementStandard,
+    ContentDescriptor,
+    LessonPlan,
+    Skill,
+    UnitPlan,
+)
+from pedagogy.progress import ProgressTracker, SoloLevel, Student
+
+
+def test_unit_plan_creation():
+    skill = Skill("Analyse data")
+    descriptor = ContentDescriptor(code="ACSSU001", description="Investigate data")
+    descriptor.add_skill(skill)
+    standard = AchievementStandard("Students analyse data")
+    standard.add_descriptor(descriptor)
+
+    unit = UnitPlan(title="Data Analysis", year_group=9)
+    unit.add_achievement_standard(standard)
+    unit.add_lesson(LessonPlan("Lesson 1"))
+
+    assert unit.achievement_standards[0].descriptors[0].skills[0].name == "Analyse data"
+    assert unit.lessons[0].title == "Lesson 1"
+
+
+def test_progress_tracking():
+    skill = Skill("Interpret graphs")
+    student = Student(name="Alice", student_id="s1")
+    tracker = ProgressTracker()
+    tracker.record_progress(student, skill, SoloLevel.RELATIONAL)
+
+    entries = tracker.get_student_progress(student)
+    assert len(entries) == 1
+    assert entries[0].solo_level is SoloLevel.RELATIONAL


### PR DESCRIPTION
## Summary
- add planning module with data classes for skills, content descriptors, achievement standards, lessons, and units
- add progress module to record student SOLO levels for skills
- include basic tests and documentation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a00485af60832cba3b1e378e0b0017